### PR TITLE
remove hashes and async

### DIFF
--- a/filetransfer.js
+++ b/filetransfer.js
@@ -1,8 +1,6 @@
 var async = require('async');
-//var webrtcsupport = require('webrtcsupport');
 var WildEmitter = require('wildemitter');
 var util = require('util');
-var hashes = require('iana-hashes');
 
 function Sender(opts) {
     WildEmitter.call(this);
@@ -10,8 +8,7 @@ function Sender(opts) {
     var options = opts || {};
     this.config = {
         chunksize: 16384,
-        pacing: 10,
-        hash: 'sha-1' // note: this uses iana hash names
+        pacing: 0
     };
     // set our config from options
     var item;
@@ -21,31 +18,22 @@ function Sender(opts) {
 
     this.file = null;
     this.channel = null;
-    this.hash = null;
 
-    // paced sender
-    // TODO: do we have to do this?
     this.processingQueue = async.queue(function (task, next) {
         if (task.type == 'chunk') {
             var reader = new window.FileReader();
             reader.onload = (function() {
                 return function(e) {
                     self.channel.send(e.target.result);
-
-                    if (self.hash) {
-                        self.hash.update(new Uint8Array(e.target.result));
-                    }
-
-                    self.emit('progress', task.start, task.file.size);
-
+                    self.emit('progress', task.start, task.file.size, e.target.result);
                     window.setTimeout(next, self.config.pacing); // pacing
                 };
             })(task.file);
             var slice = task.file.slice(task.start, task.start + task.size);
             reader.readAsArrayBuffer(slice);
         } else if (task.type == 'complete') {
-            self.emit('progress', task.file.size, task.file.size);
-            self.emit('sentFile', self.hash ? {hash: self.hash.digest('hex'), algo: self.config.hash } : null);
+            self.emit('progress', self.file.size, self.file.size);
+            self.emit('sentFile');
             next();
         }
     });
@@ -54,10 +42,6 @@ util.inherits(Sender, WildEmitter);
 
 Sender.prototype.send = function (file, channel) {
     this.file = file;
-    if (this.config.hash) {
-        this.hash = hashes.createHash(this.config.hash);
-    }
-
     this.channel = channel;
     // FIXME: hook to channel.onopen?
     for (var start = 0; start < this.file.size; start += this.config.chunksize) {
@@ -73,23 +57,13 @@ Sender.prototype.send = function (file, channel) {
     });
 };
 
-function Receiver(opts) {
+function Receiver() {
     WildEmitter.call(this);
 
-    var options = opts || {};
-    this.config = {
-        hash: 'sha-1'
-    };
-    // set our config from options
-    var item;
-    for (item in options) {
-        this.config[item] = options[item];
-    }
     this.receiveBuffer = [];
     this.received = 0;
     this.metadata = {};
     this.channel = null;
-    this.hash = null;
 }
 util.inherits(Receiver, WildEmitter);
 
@@ -99,10 +73,6 @@ Receiver.prototype.receive = function (metadata, channel) {
     if (metadata) {
         this.metadata = metadata;
     }
-    if (this.config.hash) {
-        this.hash = hashes.createHash(this.config.hash);
-    }
-
     this.channel = channel;
     // chrome only supports arraybuffers and those make it easier to calc the hash
     channel.binaryType = 'arraybuffer';
@@ -111,15 +81,8 @@ Receiver.prototype.receive = function (metadata, channel) {
         self.received += len;
         self.receiveBuffer.push(event.data);
 
-        if (self.hash) {
-            self.hash.update(new Uint8Array(event.data));
-        }
-
-        self.emit('progress', self.received, self.metadata.size);
+        self.emit('progress', self.received, self.metadata.size, event.data);
         if (self.received == self.metadata.size) {
-            if (self.hash) {
-                self.metadata.actualhash = self.hash.digest('hex');
-            }
             self.emit('receivedFile', new window.Blob(self.receiveBuffer), self.metadata);
             self.receiveBuffer = []; // discard receivebuffer
         } else if (self.received > self.metadata.size) {

--- a/hashed.js
+++ b/hashed.js
@@ -1,0 +1,54 @@
+var util = require('util');
+var hashes = require('iana-hashes');
+var base = require('./filetransfer');
+
+// drop-in replacement for filetransfer which also calculates hashes
+function Sender(opts) {
+    base.Sender.call(this, opts);
+    var self = this;
+
+    var options = opts || {};
+    if (!options.hash) {
+        options.hash = 'sha-1';
+    }
+    this.hash = hashes.createHash(options.hash);
+
+    this.on('progress', function (start, size, data) {
+        self.emit('progress', start, size, data);
+        if (data) {
+            self.hash.update(new Uint8Array(data));
+        }
+    });
+    this.on('sentFile', function () {
+        self.emit('sentFile', {hash: self.hash.digest('hex'), algo: self.config.hash });
+    });
+}
+util.inherits(Sender, base.Sender);
+
+function Receiver(opts) {
+    base.Receiver.call(this, opts);
+    var self = this;
+
+    var options = opts || {};
+    if (!options.hash) {
+        options.hash = 'sha-1';
+    }
+    this.hash = hashes.createHash(options.hash);
+
+    this.on('progress', function (start, size, data) {
+        self.emit('progress', start, size, data);
+        if (data) {
+            self.hash.update(new Uint8Array(data));
+        }
+    });
+    this.on('receivedFile', function (file, metadata) {
+        metadata.actualhash = self.hash.digest('hex');
+        self.emit('receivedFile', file, metadata);
+    });
+}
+util.inherits(Receiver, base.Receiver);
+
+module.exports = {};
+module.exports.support = base.support;
+module.exports.Sender = Sender;
+module.exports.Receiver = Receiver;


### PR DESCRIPTION
this no longer depends on either async or iana-hashes, both of which have increased the filesize alot.

I have a thing that sits on top of this and adds the hashes back. Shall we do it as requires('filetransfer/hashes') @legastero?