### PR TITLE
Ensure window is defined to prevent reference error

### DIFF
--- a/filetransfer.js
+++ b/filetransfer.js
@@ -81,6 +81,6 @@ Receiver.prototype.receive = function (metadata, channel) {
 };
 
 module.exports = {};
-module.exports.support = window && window.File && window.FileReader && window.Blob;
+module.exports.support = typeof window !== 'undefined' && window && window.File && window.FileReader && window.Blob;
 module.exports.Sender = Sender;
 module.exports.Receiver = Receiver;


### PR DESCRIPTION
Prevents a reference error from being thrown if required in a node context (or, when a module that depends on this one is required in a node context, i.e., jingle.js). @legastero @fippo 