### PR TITLE
Fix data race with offset update on sending file.

### DIFF
--- a/filetransfer.js
+++ b/filetransfer.js
@@ -52,7 +52,7 @@ Sender.prototype.send = function (file, channel) {
         channel.bufferedAmountLowThreshold = 8 * this.config.chunksize;
         channel.addEventListener('bufferedamountlow', sliceFile);
     }
-    sliceFile(0);
+    window.setTimeout(sliceFile, 0, 0);
 };
 
 function Receiver() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "filetransfer",
   "description": "file sender and receiver via webrtc datachannels",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "Philipp Hancke <fippo@andyet.net>",
   "dependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
Issue is reproducible on large files and/or slow connection between peers: sometimes offset is not updated before next `file.slice` and chunk is sending two times in a row, next chunk is just skipped.